### PR TITLE
fix: Update Shebang in Entrypoint Script for Alpine Compatibility

### DIFF
--- a/.docker-compose.yaml
+++ b/.docker-compose.yaml
@@ -3,7 +3,6 @@ version: '3'
 services:
   web:
     build: .
-    command: ./entrypoint.sh
     volumes:
       - .:/code
     ports:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ADD pyproject.toml poetry.lock /code/
 RUN pip install poetry && poetry config virtualenvs.create false && poetry install --no-dev
 
 ADD . /code/
-RUN chmod +x /code/entrypoint.sh
+ENTRYPOINT ["/code/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 python manage.py migrate
 


### PR DESCRIPTION
Alpine Linux does not come with bash pre-installed, which was causing the entrypoint script to fail. This commit updates the shebang in the entrypoint script from #!/bin/bash to #!/bin/sh, making the script compatible with Alpine Linux and fixing the issue.